### PR TITLE
Add button to panel "Send Cash" for inserting max send-able amount

### DIFF
--- a/src/java/com/vaklinov/zcashui/SendCashPanel.java
+++ b/src/java/com/vaklinov/zcashui/SendCashPanel.java
@@ -99,6 +99,7 @@ public class SendCashPanel
 	
 	private ZelCashJCheckBox  sendChangeBackToSourceAddress = null;
 	
+	private ZelCashJButton    maxAmountButton         = null;
 	private ZelCashJButton    sendButton              = null;
 	
 	private ZelCashJPanel       operationStatusPanel        = null;
@@ -181,6 +182,7 @@ public class SendCashPanel
 		tempPanel.add(destinationAmountField = new ZelCashJTextField(13));
 		destinationAmountField.setHorizontalAlignment(SwingConstants.RIGHT);
 		tempPanel.add(new ZelCashJLabel(" ZEL    "));
+		tempPanel.add(maxAmountButton = new ZelCashJButton(langUtil.getString("send.cash.panel.button.maxamount")));
 		amountPanel.add(tempPanel, BorderLayout.SOUTH);
 
 		ZelCashJPanel feePanel = new ZelCashJPanel(new BorderLayout());
@@ -251,6 +253,34 @@ public class SendCashPanel
 		operationStatusPanel.add(dividerLabel);
 		
 		// Wire the buttons
+		maxAmountButton.addActionListener(new ActionListener() 
+		{	
+			public void actionPerformed(ActionEvent e) 
+			{
+				try
+				{
+				  String balance = lastAddressBalanceData[balanceAddressCombo.getSelectedIndex()][0];
+				  String fee = transactionFeeField.getText();
+				  String max = new DecimalFormat("########0.00######").format(Double.parseDouble(balance) - Double.parseDouble(fee));
+				  destinationAmountField.setText(max);
+				} catch (Exception ex)
+				{
+					Log.error("Unexpected error: ", ex);
+					
+					String errMessage = "";
+					if (ex instanceof WalletCallException)
+					{
+						errMessage = ((WalletCallException)ex).getMessage().replace(",", ",\n");
+					}
+					
+					JOptionPane.showMessageDialog(
+							SendCashPanel.this.getRootPane().getParent(), 
+							langUtil.getString("send.cash.panel.option.pane.error.text",errMessage),
+							langUtil.getString("send.cash.panel.option.pane.error.title"),
+							JOptionPane.ERROR_MESSAGE);
+				}
+			}
+		});
 		sendButton.addActionListener(new ActionListener() 
 		{	
 			public void actionPerformed(ActionEvent e) 

--- a/src/resources/messages/zelcash_en.properties
+++ b/src/resources/messages/zelcash_en.properties
@@ -342,6 +342,7 @@ send.cash.panel.label.memo.info=<html><span style=\"font-size:0.8em;\"> \
 				* Memo may be specified only if the destination is a Z (Private) address! </span>
 send.cash.panel.label.amount=Amount to send:
 send.cash.panel.label.fee=Transaction fee:
+send.cash.panel.button.maxamount=Maximum
 send.cash.panel.button.send=Send
 send.cash.panel.label.send.warning=<html><span style=\"font-size:0.8em;\"> \
 				* When sending cash from a T (Transparent) address, the remaining unspent balance is sent to another \


### PR DESCRIPTION
This commit adds a new button to the "Send Cash" panel which allows automatic fill-in of the "Amount to send" field to the maximum send-able amount for the selected wallet.

The maximum send-able amount is the wallets balance minus fee.

![swing](https://user-images.githubusercontent.com/7348028/57194314-ba44ac00-6f45-11e9-87cb-0b63cd2aa5a5.png)
